### PR TITLE
fixed imprecision in the setup file's "register an API key" section

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -97,8 +97,8 @@ playpen list models
 
 Further details regarding the other fields of a model entry are available in the [official documentation](https://github.com/clp-research/clemcore/blob/main/docs/model_backend_registry_readme.md).
 ## Registering an API key
-There are two ways to register an API key. The first is within your environment as an environment variable. The second is within a file named `key.json`.
-For the second case, copy or rename the file called `key.json.template` contained within the project's folder.
+To register an API key, copy or rename the file called `key.json.template` contained within the project's folder as `key.json`.
+
 You may notice that there are several entries with the names of popular providers.
 In the case you are interested in running Huggingface models, insert your key under `huggingface`:
 ```json


### PR DESCRIPTION
The section in the SETUP.md file called "Register an API Key" contained a mistake. It was mentioned (I mentioned) that it was possible also to simply define an api key as an environment variable.
It is not true. The key.json file needs to exist and API keys can only be defined inside it, so I fixed the mistake.