### PR TITLE
Fixed uncomfortable behaviour for which the user always had to specify a suite in input even when trying to evaluate on a single game

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -141,9 +141,13 @@ For static benchmarks:
 playpen eval Llama-3.1-8B-Instruct --suite static
 ```
 
-If you need to run the evaluation for specific games, e.g., for wordle, you can use the `-g` option of the eval command as follows:
+If you need to run the evaluation on specific benchmarks, e.g., for wordle, you can use the `-g` option of the eval command as follows:
 ```bash
 playpen eval Llama-3.1-8B-Instruct -g wordle 
+```
+This also works with multiple games: 
+```bash
+playpen eval Llama-3.1-8B-Instruct -g wordle ifeval
 ```
 
 You may also eventually rescore episodes contained in a specific folder by indicating the folder under `-r` and setting `--skip-gameplay` to avoid rerunning the games from scratch:

--- a/SETUP.md
+++ b/SETUP.md
@@ -115,12 +115,12 @@ The mechanism is equivalent for other providers.
 To evaluate a model's gameplay performance on the `playpen-data` validation split, run the following command:
 
 ```bash
-playpen eval <model-name>
+playpen eval <model-name> --suite all
 ```
 
 where `<model-name>` should match your model's name as specified in the model registry. Connecting to the example above,
 ```bash
-playpen eval Llama-3.1-8B-Instruct
+playpen eval Llama-3.1-8B-Instruct --suite all
 ```
 
 This operation will produce a `<model-name>.val.json` file which contains two values:
@@ -320,7 +320,7 @@ once from that of the clue giver.
 
 Register your model in `model_registry.json`, then run:
 ```bash
-playpen eval Llama-3.1-8B-Instruct
+playpen eval Llama-3.1-8B-Instruct --suite all
 ```
 
 This produces a `<model-name>.val.json` file with `clemscore` and `statscore` in a `playpen-eval/<timestamp>` folder.

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -212,7 +212,7 @@ def main():
     eval_parser.add_argument("--suite", choices=["clem", "static", "all"], default=None,
                              nargs="?", type=str,
                              help="(Optional) Suite selector for the eval run."
-                                  " Default: all")
+                                  )
     eval_parser.add_argument("-g", "--game", type=str, nargs="+",
                             help="""(Optional) One or more game selectors, such as a game name or a GameSpec JSON string.""")
     eval_parser.add_argument("-r", "--results_dir", type=Path, default=get_default_results_dir(),

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -130,8 +130,8 @@ def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_di
 
     try:
         df = clem.clemeval.perform_evaluation(str(suite_results_dir), return_dataframe=True)
-    except:
-        raise ValueError("Impossible generating the result reports for your run. Check whether the requested task is part of this suite or the clembench.log file for issues caused by clemcore.")
+    except Exception as e:
+        raise ValueError("Impossible generating the result reports for your run. Check whether the requested task is part of this suite or the clembench.log file for issues caused by clemcore.") from e
     clem_score = df["-, clemscore"][0]
     return clem_score
 

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -111,10 +111,9 @@ def get_suite_game_map(game_selectors: Union[str, Dict, GameSpec, List[Union[str
             game_registry.get_game_specs_that_unify_with(game_selector))  # throws error when nothing unifies
     game_specs = list(game_specs)
     for game_spec in game_specs:
-        game_name = game_spec.game_name
-        if game_name in suite_games["clem"]:
+        if game_spec in suite_games["clem"]:
             suite_game_map["clem"].append(game_spec)
-        if game_name in suite_games["static"]:
+        if game_spec in suite_games["static"]:
             suite_game_map["static"].append(game_spec)
     return suite_game_map
 

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -110,25 +110,27 @@ def get_suite_game_map(game_selectors: Union[str, Dict, GameSpec, List[Union[str
         game_specs.update(
             game_registry.get_game_specs_that_unify_with(game_selector))  # throws error when nothing unifies
     game_specs = list(game_specs)
-    for game in game_specs:
-        game_name = game.game_name
+    for game_spec in game_specs:
+        game_name = game_spec.game_name
         if game_name in suite_games["clem"]:
-            suite_game_map["clem"].append(game)
+            suite_game_map["clem"].append(game_spec)
         if game_name in suite_games["static"]:
-            suite_game_map["static"].append(game)
+            suite_game_map["static"].append(game_spec)
     return suite_game_map
 
 
-def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selector: str,
+def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selectors: List[Union[str, Dict, GameSpec]],
                    dataset_name: str):
     suite_results_dir = results_dir / suite
     if dataset_name is not None:
         from datasets import load_dataset
         dataset = load_dataset("colab-potsdam/playpen-data", dataset_name, split="validation")
-        clem.run(game_selector, [model_spec],
+        clem.run(game_selectors, [model_spec],
                  gen_args=gen_args, results_dir_path=suite_results_dir, instances_filter=to_instances_filter(dataset))
-    clem.score(game_selector, str(suite_results_dir))
-    clem.transcripts(game_selector, str(suite_results_dir))
+    for game_selector in game_selectors:
+        clem.score(game_selector, str(suite_results_dir))
+        clem.transcripts(game_selector, str(suite_results_dir))
+
     try:
         df = clem.clemeval.perform_evaluation(str(suite_results_dir), return_dataframe=True)
     except:

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -4,12 +4,14 @@ import importlib.util as importlib_util
 import json
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Union
 from datetime import datetime
 
 import clemcore.cli as clem
 from clemcore.backends import ModelSpec, ModelRegistry, BackendRegistry
 from clemcore.clemgame import GameSpec, GameRegistry
+from numpy.f2py.auxfuncs import isstring
+
 from playpen import BasePlaypenTrainer, to_instances_filter
 
 
@@ -91,7 +93,7 @@ def get_default_results_dir():
     return results_dir
 
 
-def get_suite_game_map(game_selector:str):
+def get_suite_game_map(game_selectors: Union[str, Dict, GameSpec, List[Union[str, Dict, GameSpec]]]):
     game_registry = GameRegistry.from_directories_and_cwd_files()
     suite_game_map = {
         "clem": [],
@@ -101,11 +103,18 @@ def get_suite_game_map(game_selector:str):
         "clem": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['2.0']}")],
         "static": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['static_1.0']}")]
     }
-    game_list = [g.game_name for g in game_registry.get_game_specs_that_unify_with(game_selector)]
-    for game in game_list:
-        if game in suite_games["clem"]:
+    if not isinstance(game_selectors, list):
+        game_selectors = [game_selectors]
+    game_specs = set()
+    for game_selector in game_selectors:
+        game_specs.update(
+            game_registry.get_game_specs_that_unify_with(game_selector))  # throws error when nothing unifies
+    game_specs = list(game_specs)
+    for game in game_specs:
+        game_name = game.game_name
+        if game_name in suite_games["clem"]:
             suite_game_map["clem"].append(game)
-        if game in suite_games["static"]:
+        if game_name in suite_games["static"]:
             suite_game_map["static"].append(game)
     return suite_game_map
 
@@ -128,17 +137,17 @@ def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_di
     return clem_score
 
 
-def evaluate(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selector: str,
+def evaluate(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selectors: Union[str, Dict, GameSpec, List[Union[str, Dict, GameSpec]]],
              skip_gameplay: bool):
     overall_results_file = results_dir / f"{model_spec.model_name}.val.json"
-    if suite is None and game_selector is None:
+    if suite is None and game_selectors is None:
         raise ValueError("Either `suite` or `game_selector` must be specified.")
-    elif suite is not None and game_selector is None:
+    elif suite is not None and game_selectors is None:
         print(f"Suite {suite} selected for the evaluation.")
-        game_selector = ["{'benchmark':['2.0']}", "{'benchmark':['static_1.0']}"] if suite == "all" else ["{'benchmark':['static_1.0']}"] if suite == "static" else ["{'benchmark':['2.0']}"]
-    elif suite is not None and game_selector is not None:
+        game_selectors = ["{'benchmark':['2.0']}", "{'benchmark':['static_1.0']}"] if suite == "all" else ["{'benchmark':['static_1.0']}"] if suite == "static" else ["{'benchmark':['2.0']}"]
+    elif suite is not None and game_selectors is not None:
         print("You have specified both `suite` and `game_selector`. When you select a game_selector a suite is detected automatically for each game.")
-    suite_game_map = get_suite_game_map(game_selector)
+    suite_game_map = get_suite_game_map(game_selectors)
 
     for suite, games in suite_game_map.items():
         if len(games) > 0:
@@ -205,10 +214,8 @@ def main():
                              nargs="?", type=str,
                              help="(Optional) Suite selector for the eval run."
                                   " Default: all")
-    eval_parser.add_argument("-g", "--game", type=str,
-                             help="(Optional) Game selector, such as a game name or a GameSpec JSON string."
-                                  " Default: {\"benchmark\": [\"2.0\"]} (clem suite)"
-                                  " or {\"benchmark\": [\"static_1.0\"]} (static suite)")
+    eval_parser.add_argument("-g", "--game", type=str, nargs="+",
+                            help="""(Optional) One or more game selectors, such as a game name or a GameSpec JSON string.""")
     eval_parser.add_argument("-r", "--results_dir", type=Path, default=get_default_results_dir(),
                              help="(Optional) Relative or absolute path to a playpen-eval results directory."
                                   " This is expected to be one level above 'clem' or 'static' results."

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -10,8 +10,6 @@ from datetime import datetime
 import clemcore.cli as clem
 from clemcore.backends import ModelSpec, ModelRegistry, BackendRegistry
 from clemcore.clemgame import GameSpec, GameRegistry
-from numpy.f2py.auxfuncs import isstring
-
 from playpen import BasePlaypenTrainer, to_instances_filter
 
 
@@ -100,8 +98,8 @@ def get_suite_game_map(game_selectors: Union[str, Dict, GameSpec, List[Union[str
         "static": []
     }
     suite_games = {
-        "clem": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['2.0']}")],
-        "static": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['static_1.0']}")]
+        "clem": [g for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['2.0']}")],
+        "static": [g for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['static_1.0']}")]
     }
     if not isinstance(game_selectors, list):
         game_selectors = [game_selectors]
@@ -111,11 +109,10 @@ def get_suite_game_map(game_selectors: Union[str, Dict, GameSpec, List[Union[str
             game_registry.get_game_specs_that_unify_with(game_selector))  # throws error when nothing unifies
     game_specs = list(game_specs)
     for game_spec in game_specs:
-        game_name = game_spec.game_name
-        if game_name in suite_games["clem"]:
-            suite_game_map["clem"].append(game_spec)
-        if game_name in suite_games["static"]:
-            suite_game_map["static"].append(game_spec)
+        if game_spec in suite_games["clem"]:
+            suite_game_map["clem"].append(game_spec.game_name)
+        if game_spec in suite_games["static"]:
+            suite_game_map["static"].append(game_spec.game_name)
     return suite_game_map
 
 

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -150,7 +150,7 @@ def evaluate(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Pat
 
     for suite, games in suite_game_map.items():
         if len(games) > 0:
-            dataset_name = None if skip_gameplay else "instances"
+            dataset_name = None if skip_gameplay else ("instances" if suite == "clem" else "instances-static")
             clem_score = evaluate_suite(suite, model_spec, gen_args, results_dir, games, dataset_name)
             store_eval_score(overall_results_file, "clemscore" if suite == "clem" else "statscore", clem_score)
 

--- a/playpen/cli.py
+++ b/playpen/cli.py
@@ -85,22 +85,30 @@ def store_eval_score(file_path: Path, name: str, value):
     return new_scores
 
 
-
 def get_default_results_dir():
     timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     results_dir = Path("playpen-eval") / timestamp
     return results_dir
 
-def game_selector_in_suite(suite: str, game_selector: str):
+
+def get_suite_game_map(game_selector:str):
     game_registry = GameRegistry.from_directories_and_cwd_files()
-    suite_selector = "{'benchmark':['2.0']}" if suite == "clem" else "{'benchmark':['static_1.0']}"
-    suite_game_list = [g.game_name for g in game_registry.get_game_specs_that_unify_with(suite_selector)]
+    suite_game_map = {
+        "clem": [],
+        "static": []
+    }
+    suite_games = {
+        "clem": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['2.0']}")],
+        "static": [g.game_name for g in game_registry.get_game_specs_that_unify_with("{'benchmark':['static_1.0']}")]
+    }
     game_list = [g.game_name for g in game_registry.get_game_specs_that_unify_with(game_selector)]
-    in_suite = True
     for game in game_list:
-        if game not in suite_game_list:
-            in_suite = False
-    return in_suite
+        if game in suite_games["clem"]:
+            suite_game_map["clem"].append(game)
+        if game in suite_games["static"]:
+            suite_game_map["static"].append(game)
+    return suite_game_map
+
 
 def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selector: str,
                    dataset_name: str):
@@ -123,39 +131,20 @@ def evaluate_suite(suite: str, model_spec: ModelSpec, gen_args: Dict, results_di
 def evaluate(suite: str, model_spec: ModelSpec, gen_args: Dict, results_dir: Path, game_selector: str,
              skip_gameplay: bool):
     overall_results_file = results_dir / f"{model_spec.model_name}.val.json"
-    if suite is None and game_selector not in ["{'benchmark':['2.0']}","{'benchmark':['static_1.0']}"]:
-        raise ValueError("No suite specified! Specify a suite among the available options (clem, static, all). In case of clem or static suites, you may also specify a game name in order to evaluate on a single benchmark instead of the entire suite.")
-    elif suite is None and game_selector in ["{'benchmark':['2.0']}","{'benchmark':['static_1.0']}"]:
-        suite = "clem" if game_selector == "{'benchmark':['2.0']}" else "static"
-        game_selector = None
-        print(f"Game Selector `{game_selector}` found. Setting the suite to '{suite}'.")
+    if suite is None and game_selector is None:
+        raise ValueError("Either `suite` or `game_selector` must be specified.")
     elif suite is not None and game_selector is None:
         print(f"Suite {suite} selected for the evaluation.")
+        game_selector = ["{'benchmark':['2.0']}", "{'benchmark':['static_1.0']}"] if suite == "all" else ["{'benchmark':['static_1.0']}"] if suite == "static" else ["{'benchmark':['2.0']}"]
     elif suite is not None and game_selector is not None:
-        if suite == "all":
-            print("The selected suite is `all`. Ignoring any eventual game specified under the `-g` argument.")
-            game_selector = None
-        elif game_selector in ["{'benchmark':['2.0']}","{'benchmark':['static_1.0']}"]:
-            print(f"You have both set suite {suite} and game selector {game_selector}, however this game selector is an alias for a suite! Ignoring game selector. Please either set the suite to None or change the game selector if this was not your intended behaviour.")
-            game_selector = None
-        else:
-            if not game_selector_in_suite(suite, game_selector):
-                raise ValueError(f"You have selected suite `{suite}` and game selector `{game_selector}`, but the game selector is not associated with the suite.")
-            print(f"Suite `{suite}` and game selector `{game_selector}` selected.")
+        print("You have specified both `suite` and `game_selector`. When you select a game_selector a suite is detected automatically for each game.")
+    suite_game_map = get_suite_game_map(game_selector)
 
-
-    if suite in ["all", "clem"]:
-        dataset_name = None if skip_gameplay else "instances"
-        _game_selector = GameSpec.from_dict({"benchmark": ["2.0"]}, allow_underspecified=True) \
-            if game_selector is None else game_selector
-        clem_score = evaluate_suite("clem", model_spec, gen_args, results_dir, _game_selector, dataset_name)
-        store_eval_score(overall_results_file, "clemscore", clem_score)
-    if suite in ["all", "static"]:
-        dataset_name = None if skip_gameplay else "instances-static"
-        _game_selector = GameSpec.from_dict({"benchmark": ["static_1.0"]}, allow_underspecified=True) \
-            if game_selector is None else game_selector
-        stat_score = evaluate_suite("static", model_spec, gen_args, results_dir, _game_selector, dataset_name)
-        store_eval_score(overall_results_file, "statscore", stat_score)
+    for suite, games in suite_game_map.items():
+        if len(games) > 0:
+            dataset_name = None if skip_gameplay else "instances"
+            clem_score = evaluate_suite(suite, model_spec, gen_args, results_dir, games, dataset_name)
+            store_eval_score(overall_results_file, "clemscore" if suite == "clem" else "statscore", clem_score)
 
 
 def cli(args: argparse.Namespace):
@@ -212,7 +201,7 @@ def main():
                                          description="Run the playpen eval pipelines to compute clem- and statscore.")
     eval_parser.add_argument("model", type=str,
                              help="The model name of the model to be evaluated (as listed by 'playpen list models').")
-    eval_parser.add_argument("--suite", choices=["clem", "static", "all"], default='all',
+    eval_parser.add_argument("--suite", choices=["clem", "static", "all"], default=None,
                              nargs="?", type=str,
                              help="(Optional) Suite selector for the eval run."
                                   " Default: all")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -57,6 +57,14 @@ class EvaluateTest(unittest.TestCase):
         evaluate(None, self.model_spec, self.gen_args, self.results_dir, "wordle", False)
         self.mock_get_suite_game_map.assert_called_once_with("wordle")
 
+    def test_list_of_game_selectors_without_suite(self):
+        evaluate(None, self.model_spec, self.gen_args, self.results_dir, ["wordle", "taboo"], False)
+        self.mock_get_suite_game_map.assert_called_once_with(["wordle", "taboo"])
+
+    def test_list_of_game_selectors_with_suite(self):
+        evaluate("clem", self.model_spec, self.gen_args, self.results_dir, ["wordle", "taboo"], False)
+        self.mock_get_suite_game_map.assert_called_once_with(["wordle", "taboo"])
+
     # ------------------------------------------------------------------ #
     # skip_gameplay / dataset_name                                         #
     # ------------------------------------------------------------------ #

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -12,13 +12,12 @@ class EvaluateTest(unittest.TestCase):
         self.model_spec.model_name = "test-model"
         self.gen_args = {"temperature": 0.0, "max_tokens": 300}
         self.results_dir = Path("/tmp/test-results")
-        self.mock_game_spec = MagicMock()
 
         self.mock_evaluate_suite = patch("playpen.cli.evaluate_suite").start()
         self.mock_evaluate_suite.return_value = 0.5
 
-        self.mock_game_spec_cls = patch("playpen.cli.GameSpec").start()
-        self.mock_game_spec_cls.from_dict.return_value = self.mock_game_spec
+        self.mock_get_suite_game_map = patch("playpen.cli.get_suite_game_map").start()
+        self.mock_get_suite_game_map.return_value = {"clem": ["wordle"], "static": []}
 
         self.mock_store = patch("playpen.cli.store_eval_score").start()
 
@@ -29,95 +28,34 @@ class EvaluateTest(unittest.TestCase):
     # Error cases                                                          #
     # ------------------------------------------------------------------ #
 
-    def test_no_suite_error_game_selected(self):
-        with self.assertRaises(ValueError):
-            evaluate(None, self.model_spec, self.gen_args, self.results_dir, "wordle", False)
-
-    def test_no_suite_error_no_game_selected(self):
+    def test_no_suite_no_game_raises_value_error(self):
         with self.assertRaises(ValueError):
             evaluate(None, self.model_spec, self.gen_args, self.results_dir, None, False)
 
-    def test_game_selector_not_in_clem_suite_error(self):
-        with self.assertRaises(ValueError):
-            evaluate("clem", self.model_spec, self.gen_args, self.results_dir, "mmlu_pro", False)
-
-    def test_game_selector_not_in_static_suite_error(self):
-        with self.assertRaises(ValueError):
-            evaluate("static", self.model_spec, self.gen_args, self.results_dir, "wordle", False)
-
     # ------------------------------------------------------------------ #
-    # Suite selection                                                      #
+    # Suite selection / game_selector derivation                          #
     # ------------------------------------------------------------------ #
 
-    def evaluate_suite_clem(self):
+    def test_suite_clem_sets_clem_game_selector(self):
         evaluate("clem", self.model_spec, self.gen_args, self.results_dir, None, False)
+        self.mock_get_suite_game_map.assert_called_once()
+        called_with = self.mock_get_suite_game_map.call_args[0][0]
+        self.assertIn("{'benchmark':['2.0']}", called_with)
 
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][0], "clem")
-
-    def evaluate_suite_static(self):
-        evaluate("static", self.model_spec, self.gen_args, self.results_dir, None, False)
-
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][0], "static")
-
-    def evaluate_suite_all(self):
+    def test_suite_all_sets_both_game_selectors(self):
         evaluate("all", self.model_spec, self.gen_args, self.results_dir, None, False)
+        self.mock_get_suite_game_map.assert_called_once()
+        called_with = self.mock_get_suite_game_map.call_args[0][0]
+        self.assertIn("{'benchmark':['2.0']}", called_with)
+        self.assertIn("{'benchmark':['static_1.0']}", called_with)
 
-        self.assertEqual(self.mock_evaluate_suite.call_count, 2)
-        suite_names = [c[0][0] for c in self.mock_evaluate_suite.call_args_list]
-        self.assertIn("clem", suite_names)
-        self.assertIn("static", suite_names)
-
-    # ------------------------------------------------------------------ #
-    # Benchmark alias auto-detection                                       #
-    # ------------------------------------------------------------------ #
-
-    def test_clem_benchmark_alias_auto_sets_clem_suite(self):
-        evaluate(None, self.model_spec, self.gen_args, self.results_dir,
-                 "{'benchmark':['2.0']}", False)
-
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][0], "clem")
-
-    def test_static_benchmark_alias_auto_sets_static_suite(self):
-        evaluate(None, self.model_spec, self.gen_args, self.results_dir,
-                 "{'benchmark':['static_1.0']}", False)
-
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][0], "static")
-
-    # ------------------------------------------------------------------ #
-    # game_selector handling                                               #
-    # ------------------------------------------------------------------ #
-
-    def test_all_suite_ignores_game_selector(self):
-        """suite='all' must set game_selector to None, so _game_selector = GameSpec.from_dict(...)."""
-        evaluate("all", self.model_spec, self.gen_args, self.results_dir, "wordle", False)
-
-        self.assertEqual(self.mock_evaluate_suite.call_count, 2)
-        for c in self.mock_evaluate_suite.call_args_list:
-            self.assertNotEqual(c[0][4], "wordle")
-
-    def test_specific_game_selector_is_passed_through_for_clem_suite(self):
+    def test_both_suite_and_game_selector_does_not_raise(self):
         evaluate("clem", self.model_spec, self.gen_args, self.results_dir, "wordle", False)
+        self.mock_get_suite_game_map.assert_called_once_with("wordle")
 
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][4], "wordle")
-
-    def test_specific_game_selector_is_passed_through_for_static_suite(self):
-        evaluate("static", self.model_spec, self.gen_args, self.results_dir, "mmlu_pro", False)
-
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][4], "mmlu_pro")
-
-    def test_benchmark_alias_game_selector_ignored_when_suite_is_set(self):
-        """If suite='clem' and game_selector is the clem alias, game_selector is dropped."""
-        evaluate("clem", self.model_spec, self.gen_args, self.results_dir,
-                 "{'benchmark':['2.0']}", False)
-
-        self.mock_evaluate_suite.assert_called_once()
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][4], self.mock_game_spec)
+    def test_game_selector_without_suite_does_not_raise(self):
+        evaluate(None, self.model_spec, self.gen_args, self.results_dir, "wordle", False)
+        self.mock_get_suite_game_map.assert_called_once_with("wordle")
 
     # ------------------------------------------------------------------ #
     # skip_gameplay / dataset_name                                         #
@@ -125,42 +63,32 @@ class EvaluateTest(unittest.TestCase):
 
     def test_skip_gameplay_passes_none_as_dataset_name(self):
         evaluate("clem", self.model_spec, self.gen_args, self.results_dir, None, True)
-
         self.assertIsNone(self.mock_evaluate_suite.call_args[0][5])
 
-    def test_no_skip_gameplay_passes_instances_for_clem(self):
+    def test_no_skip_gameplay_passes_instances(self):
         evaluate("clem", self.model_spec, self.gen_args, self.results_dir, None, False)
-
         self.assertEqual(self.mock_evaluate_suite.call_args[0][5], "instances")
-
-    def test_no_skip_gameplay_passes_instances_static_for_static(self):
-        evaluate("static", self.model_spec, self.gen_args, self.results_dir, None, False)
-
-        self.assertEqual(self.mock_evaluate_suite.call_args[0][5], "instances-static")
 
     # ------------------------------------------------------------------ #
     # store_eval_score calls                                               #
     # ------------------------------------------------------------------ #
 
-    def test_clemscore_is_stored_after_clem_eval(self):
+    def test_clemscore_is_stored_after_eval(self):
         evaluate("clem", self.model_spec, self.gen_args, self.results_dir, None, False)
-
         expected_file = self.results_dir / f"{self.model_spec.model_name}.val.json"
         self.mock_store.assert_called_once_with(expected_file, "clemscore", 0.5)
 
-    def test_statscore_is_stored_after_static_eval(self):
-        evaluate("static", self.model_spec, self.gen_args, self.results_dir, None, False)
-
-        expected_file = self.results_dir / f"{self.model_spec.model_name}.val.json"
-        self.mock_store.assert_called_once_with(expected_file, "statscore", 0.5)
-
-    def test_both_scores_are_stored_for_all_suite(self):
+    def test_suites_with_games_each_store_clemscore(self):
+        self.mock_get_suite_game_map.return_value = {"clem": ["wordle"], "static": ["mmlu_pro"]}
         evaluate("all", self.model_spec, self.gen_args, self.results_dir, None, False)
-
         self.assertEqual(self.mock_store.call_count, 2)
         stored_keys = [c[0][1] for c in self.mock_store.call_args_list]
-        self.assertIn("clemscore", stored_keys)
-        self.assertIn("statscore", stored_keys)
+        self.assertEqual(stored_keys, ["clemscore", "statscore"])
+
+    def test_empty_suite_does_not_store_score(self):
+        self.mock_get_suite_game_map.return_value = {"clem": [], "static": []}
+        evaluate("clem", self.model_spec, self.gen_args, self.results_dir, None, False)
+        self.mock_store.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR, I changed the evaluation pipeline to make it more uniformed with that of clemcore. it is now also possible to specify a list of games as input.

Also, before this PR it was always required to specify a suite in input (also when the user wanted to evaluate on a single game). The game had to be contained within the suite or an error was thrown.
This was an extra typing effort for the user (the codebase worked fine and would evaluate successfully only on the desired game).
Now a suite is detected automatically for each input game so that the user doesn't have to worry about this.

The SETUP.md file has been updated to include an example for the evaluation for multiple games together